### PR TITLE
fix non-standard tag parse error

### DIFF
--- a/pxfilter.py
+++ b/pxfilter.py
@@ -183,6 +183,8 @@ class XssHtml(HTMLParser):
         return attrs
 
     def _htmlspecialchars(self, html):
+        if not html:
+            return ''
         return html.replace("<", "&lt;")\
             .replace(">", "&gt;")\
             .replace('"', "&quot;")\


### PR DESCRIPTION
When html parse feed a non-standard tag, parse will raise error.

```
parser.feed('''<p><img src onerror="alert('xss1')"/></p>''')

/root/projects/python-xss-filter/pxfilter.py in _htmlspecialchars(self, html)
    184
    185     def _htmlspecialchars(self, html):
--> 186         return html.replace("<", "&lt;")\
    187             .replace(">", "&gt;")\
    188             .replace('"', "&quot;")\
```

after fix, it will be:

```
'<p><img src="" /></p>'
```
