### PR TITLE
修复过滤可能导致的换行符丢失的问题

### DIFF
--- a/pxfilter.py
+++ b/pxfilter.py
@@ -58,10 +58,9 @@ class XssHtml(HTMLParser):
         Get the safe html code
         """
         for i in range(0, len(self.result)):
-            tmp = self.result[i].rstrip('\n')
-            tmp = tmp.lstrip('\n')
+            tmp = self.result[i].strip('\n')
             if tmp:
-                self.data.append(tmp)
+                self.data.append(self.result[i])
         return ''.join(self.data)
 
     def handle_startendtag(self, tag, attrs):


### PR DESCRIPTION
在`getHtml()`方法中，原意是判断并排除空的html token，但是在拼接html的时候，使用的是去除换行的html，这就可能导致原来的html发生改变。

比如

``` html
<pre><code>#include &lt;stdio.h&gt;
using namespace std;
int main(){
    int a, b;
    scanf("%d%d", &amp;a, &amp;b);
    printf("%d", a+b);
    return 0;
}</code></pre>
```

过滤后就会丢失`using namespace std;`前面的换行。

同时优化`strip()`的用法，`strip() = lstrip() + rstrip()`。
